### PR TITLE
Implement the basic job center functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Job center:- A simple job management service 
 ============================================
+![Build Status](https://github.com/lgmfred/job_center/actions/workflows/ci.yml/badge.svg)
 
 A terrible solution to the **Chapter 22** exercise in Joe's [Programming Erlang (2nd edition)](https://pragprog.com/titles/jaerlang2/programming-erlang-2nd-edition/). _Read the book if you haven't already. It's good!_
 

--- a/apps/job_center/src/job_center.app.src
+++ b/apps/job_center/src/job_center.app.src
@@ -1,7 +1,7 @@
 {application, job_center,
  [{description, "A simple job management service"},
   {vsn, "0.1.0"},
-  {registered, []},
+  {registered, [job_center_sup, job_center_serv]},
   {mod, {job_center, []}},
   {applications,
    [kernel,

--- a/apps/job_center/src/job_center.erl
+++ b/apps/job_center/src/job_center.erl
@@ -6,13 +6,39 @@
 -behaviour(application).
 
 -export([start/2, stop/1]).
+-export([add_job/1, work_wanted/0, job_done/1]).
 
--spec start(application:start_type(), term()) -> {ok, pid()} | {ok, pid(), term()} | {error, term()}.
-start(_StartType, _StartArgs) ->
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Application behaviour
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% @hidden
+-spec start(application:start_type(), term()) ->
+    {ok, pid()} | {ok, pid(), term()} | {error, term()}.
+start(_StartType, _Args) ->
     job_center_sup:start_link().
 
+%% @hidden
 -spec stop(term()) -> ok.
 stop(_State) ->
     ok.
 
-%% internal functions
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Public API
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% @doc Add a job to the job queue
+-spec add_job(fun()) -> non_neg_integer().
+add_job(Fun) ->
+    job_center_serv:add_job(Fun).
+
+%% @doc Request work
+-spec work_wanted() -> {integer(), fun()} | no.
+work_wanted() ->
+    job_center_serv:work_wanted().
+
+%% @doc Signal that a job has been done
+-spec job_done(integer()) -> ok.
+job_done(Int) ->
+    job_center_serv:job_done(Int).
+

--- a/apps/job_center/src/job_center_serv.erl
+++ b/apps/job_center/src/job_center_serv.erl
@@ -1,0 +1,95 @@
+%%% The core server in charge of tracking jobs.
+-module(job_center_serv).
+-behaviour(gen_server).
+
+-define(SERVER, ?MODULE).
+
+%% Public API
+-export([start_link/0,
+         stop/0,
+         add_job/1,
+         work_wanted/0,
+         job_done/1
+        ]).
+
+%% Internal API for tests
+-export([get_state/0]).
+
+%% gen_server callbacks
+-export([init/1,
+         handle_call/3,
+         handle_cast/2
+        % handle_info/2,
+        % terminate/2,
+        % code_change/3
+        ]).
+
+-type state() :: #{int => integer(),
+                   queue => queue:queue(),
+                   in_progress => list(),
+                   done => list()}.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% INTERFACE FUNCTIONS %%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%
+-spec start_link() -> {ok, pid()} | ignore | {error, term()}. 
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+-spec stop() -> stopped.
+stop() ->
+    gen_server:call(?MODULE, stop).
+
+-spec get_state() -> queue:queue().
+get_state() ->
+    gen_server:call(?MODULE, get_state).
+
+-spec add_job(fun()) -> non_neg_integer().
+add_job(Fun) ->
+    gen_server:call(?MODULE, {add_job, Fun}).
+
+-spec work_wanted() -> {integer(), fun()} | no.
+work_wanted() ->
+    gen_server:call(?MODULE, work_wanted).
+
+-spec job_done(integer()) -> ok.
+job_done(Int) ->
+    gen_server:cast(?MODULE, {job_done, Int}).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% GEN_SERVER CALLBACKS %%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+-spec init(list()) -> {ok, state()}.
+init([]) -> 
+    State = #{int => 1,
+              queue => queue:new(),
+              in_progress => [],
+              done => []},
+    {ok, State}.
+
+-spec handle_call(atom() | tuple(),_,_) -> {'reply',_,_} | {'stop','normal','stopped',_}.
+handle_call({add_job, Fun}, _From, State) ->
+    #{int := N, queue := Q} = State,
+    {reply, N, State#{int := N + 1, queue := queue:in({N, Fun}, Q)}};
+handle_call(work_wanted, _From, State) ->
+    #{queue := Q, in_progress := L} = State,
+    case queue:out(Q) of
+        {{value, Work}, Q2} -> 
+            {reply, Work, State#{queue := Q2, in_progress := [Work|L]}};
+        {empty, _} ->
+            {reply, no, State}
+    end;
+handle_call(get_state, _From, State) ->
+    {reply, State, State};
+handle_call(stop, _From, State) ->
+    {stop, normal, stopped, State}.
+
+-spec handle_cast(_,_) -> {noreply,_}.
+handle_cast({job_done, N}, #{in_progress := Pl, done := Dl} = State) ->
+    case lists:keysearch(N, 1, Pl) of
+        {value, Tuple} -> 
+            NewPl = lists:keydelete(N, 1, Pl),
+            {noreply, State#{in_progress := NewPl, done := [Tuple|Dl]}};
+        false ->
+            {noreply, State}
+    end.

--- a/apps/job_center/src/job_center_sup.erl
+++ b/apps/job_center/src/job_center_sup.erl
@@ -17,9 +17,20 @@ start_link() ->
 
 -spec init(term()) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}} | ignore.
 init([]) ->
-    SupFlags = #{strategy => one_for_all,
-                 intensity => 0,
-                 period => 1},
-    ChildSpecs = [],
+    SupFlags = #{strategy => one_for_one,
+                 intensity => 1,
+                 period => 3600},
+    ChildSpecs = [child(job_center_serv)],
     {ok, {SupFlags, ChildSpecs}}.
 
+
+%% @hidden
+-spec child(module()) -> supervisor:child_spec().
+child(Mod) ->
+    #{id => Mod,
+      start => {Mod, start_link, []},
+      restart => permanent,
+      shutdown => 2000,
+      type => worker,
+      modules => [Mod]
+     }.

--- a/apps/job_center/test/job_center_serv_tests.erl
+++ b/apps/job_center/test/job_center_serv_tests.erl
@@ -1,0 +1,139 @@
+-module(job_center_serv_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(setup(F), {setup, fun start/0, fun stop/1, F}).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% TESTS DESCRIPTIONS %%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%
+-spec start_stop_test_() -> [tuple()].
+start_stop_test_() ->
+    [{"The server can be started, stopped and has a registered name",
+      ?setup(fun is_registered/1)},
+     {"The queue, in_progress and done status parameters are initially empty",
+      ?setup(fun initially_empty_params/1)}].
+
+-spec add_job_test_() -> tuple().
+add_job_test_() ->
+    {"Adding a job returns job number and adds the job to the queue",
+     ?setup(fun add_job/1)}.
+
+-spec work_wanted_test_() -> tuple().
+work_wanted_test_() ->
+    [{"A worker process can request for work",
+      ?setup(fun work_wanted/1)},
+     {"Requested work is moved from the queue to in_progress list",
+      ?setup(fun queue_to_progress_list/1)}].
+
+-spec job_done_test_() -> tuple().
+job_done_test_() ->
+    {"Signal that a work has been done and that moves it to done list",
+      ?setup(fun job_done/1)}.
+
+%%%%%%%%%%%%%%%%%%%%%%%
+%%% SETUP FUNCTIONS %%%
+%%%%%%%%%%%%%%%%%%%%%%%
+-spec start() -> pid().
+start() ->
+    {ok, Pid} = job_center_serv:start_link(),
+    Pid.
+
+-spec stop(pid()) -> ok.
+stop(_Pid) ->
+    job_center_serv:stop().
+
+%%%%%%%%%%%%%%%%%%%%
+%%% ACTUAL TESTS %%%
+%%%%%%%%%%%%%%%%%%%%
+-spec is_registered(pid()) -> [ok].
+is_registered(Pid) ->
+    [?_assert(is_process_alive(Pid)),
+     ?_assertEqual(Pid, whereis(job_center_serv))].
+
+-spec initially_empty_params(pid()) -> [ok].
+initially_empty_params(_Pid) ->
+    S = job_center_serv:get_state(),
+    #{int := N, queue := Q, in_progress := L1, done := L2 } = S,
+    [?_assert(is_map(S)),
+     ?_assert(is_integer(N)),
+     ?_assertEqual(1, N),
+     ?_assert(queue:is_queue(Q)),
+     ?_assert(queue:is_empty(Q)),
+     ?_assertEqual([], L1),
+     ?_assertEqual([], L2)].
+
+-spec add_job(pid()) -> [ok].
+add_job(_Pid) ->
+    F1 = fun() -> some_job end,
+    F2 = fun(X) -> X * 2 end,
+    F3 = fun(X, Y) -> X * Y end,
+    L1 = [job_center:add_job(X) || X <- [F1, F2, F3]],
+    L2 = [Z || Z <- L1, is_integer(Z)],
+    #{queue := Q} = job_center_serv:get_state(),
+    L3 = queue:to_list(Q),
+    [?_assertEqual(L1, L2),
+     ?_assertEqual(L1, [1,2,3]),
+     ?_assert(queue:is_queue(Q)),
+     ?_assertEqual([{1,F1},{2,F2},{3,F3}], L3)].
+
+-spec work_wanted(pid()) -> [ok].
+work_wanted(_Pid) ->
+    J1 = job_center:work_wanted(),
+    F1 = fun() -> uno end,
+    F2 = fun() -> 2 end,
+    F3 = fun() -> trois end,
+    L1 = [{1, F1}, {2, F2}, {3, F3}],
+    [job_center:add_job(X) || X <- [F1, F2, F3]],
+    L2 = [job_center:work_wanted() || _W <- lists:seq(1, 3)], 
+    J2 = job_center:work_wanted(),
+    job_center:add_job(fun() -> 77 * 7 end),
+    {N, Fun} = job_center:work_wanted(),
+    L3 = [Y() || {_, Y} <- L2],
+    [?_assertEqual(no, J1),
+     ?_assertEqual(no, J2),
+     ?_assertEqual(L1, L2),
+     ?_assertEqual([uno, 2, trois], L3),
+     ?_assert(is_integer(N)),
+     ?_assert(is_function(Fun)),
+     ?_assertEqual(539, Fun())
+    ].
+
+-spec queue_to_progress_list(pid()) -> [ok].
+queue_to_progress_list(_Pid) ->
+    F1 = fun() -> 1 end,
+    N1 = job_center_serv:add_job(F1),
+    #{queue := Q1, in_progress := PL1} = job_center_serv:get_state(),
+    W1 = job_center:work_wanted(),
+    #{queue := Q2, in_progress := PL2} = job_center_serv:get_state(),
+    Lx = [fun() -> Xx end || Xx <- lists:seq(2, 5)],
+    L3 = [job_center:add_job(X) || X <- Lx],
+    #{queue := Q3, in_progress := [W1]} = job_center_serv:get_state(),
+    L4 = [job_center:work_wanted() || _Yy <- L3],
+    #{queue := Q4, in_progress := PL4} = job_center_serv:get_state(),
+    [?_assert(false == queue:is_empty(Q1)),
+     ?_assert(queue:member({N1, F1}, Q1)),
+     ?_assertEqual([], PL1),
+     ?_assert(queue:is_empty(Q2)),
+     ?_assert(lists:member(W1, PL2)),
+     ?_assertEqual(lists:zip(lists:seq(2, 5), Lx), queue:to_list(Q3)),
+     ?_assert(queue:is_empty(Q4)),
+     ?_assertEqual([W1|L4], lists:sort(PL4))].
+
+-spec job_done(pid()) -> [ok].
+job_done(_Pid) ->
+    #{done := DL1} = job_center_serv:get_state(),
+    [job_center:add_job(X) || X <- [fun() -> Y end || Y <- lists:seq(1, 15)]],
+    L1 = [job_center:work_wanted() || _ <- lists:seq(1, 15)],
+    [job_center:job_done(Xx) || Xx <- lists:seq(16, 30)], 
+    #{done := DL2} = job_center_serv:get_state(),
+    [job_center:job_done(Wn) || {Wn, _} <- L1],
+    #{done := DL3} = job_center_serv:get_state(),
+    [?_assertEqual({[],[]}, {DL1, DL2}),
+     ?_assertEqual(L1, lists:sort(DL3))].
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%
+%%% HELPER FUNCTIONS %%%
+%%%%%%%%%%%%%%%%%%%%%%%%
+
+

--- a/apps/job_center/test/job_center_tests.erl
+++ b/apps/job_center/test/job_center_tests.erl
@@ -1,0 +1,20 @@
+-module(job_center_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+-spec app_test_() -> tuple().
+app_test_() ->
+    {"Job center application can be started and stopped",
+     {inorder,
+      [?_assert(try application:start(job_center) of
+                    ok -> true;
+                    {error, {already_started, job_center}} -> true;
+                    _ -> false
+                catch
+                    _:_ -> false
+                end),
+       ?_assert(try application:stop(job_center) of
+                    ok -> true;
+                    _ -> false
+                catch
+                    _:_ -> false
+                end)]}}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 %% Aliases
 {alias, [
     {check, [
-        xref, dialyzer, eunit, ct, {cover, "-v"}
+        xref, dialyzer, eunit, {cover, "-v"}
     ]}
 ]}.
 
@@ -24,6 +24,9 @@
     warn_untyped_record,
     debug_info
 ]}.
+
+%% Plugins
+{project_plugins, [{rebar3_typer, "~> 0.0.1"}]}.
 
 %% Dependencies
 {deps, []}.


### PR DESCRIPTION
As in #1, this includes:
- Start the job center server.
- Add a job to the job queue.
- Request work.
- Signal that a job has been done.